### PR TITLE
Hotfix/nova document caseworker

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2024-04-10
+
+### Fixed
+
+- Documents in Nova can now have a caseworker assigned.
+
 ## [2.1.0] - 2024-04-09
 
 ### Added
@@ -88,7 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased] https://github.com/itk-dev-rpa/ITK-dev-shared-components/compare/2.1.0...HEAD
+[Unreleased] https://github.com/itk-dev-rpa/ITK-dev-shared-components/compare/2.1.1...HEAD
+[2.1.1] https://github.com/itk-dev-rpa/ITK-dev-shared-components/releases/tag/2.1.1
 [2.1.0] https://github.com/itk-dev-rpa/ITK-dev-shared-components/releases/tag/2.1.0
 [2.0.0] https://github.com/itk-dev-rpa/ITK-dev-shared-components/releases/tag/2.0.0
 [1.3.1] https://github.com/itk-dev-rpa/ITK-dev-shared-components/releases/tag/1.3.1

--- a/itk_dev_shared_components/kmd_nova/nova_objects.py
+++ b/itk_dev_shared_components/kmd_nova/nova_objects.py
@@ -48,6 +48,7 @@ class Document:
     file_extension: Optional[str] = None
     category_name: Optional[str] = None
     category_uuid: Optional[str] = None
+    caseworker: Optional[Caseworker] = None
 
 
 @dataclass(slots=True, kw_only=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "itk_dev_shared_components"
-version = "2.1.0"
+version = "2.1.1"
 authors = [
   { name="ITK Development", email="itk-rpa@mkb.aarhus.dk" },
 ]

--- a/tests/test_nova_api/test_documents.py
+++ b/tests/test_nova_api/test_documents.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from io import StringIO, BytesIO
 
 from itk_dev_shared_components.kmd_nova.authentication import NovaAccess
-from itk_dev_shared_components.kmd_nova.nova_objects import Document
+from itk_dev_shared_components.kmd_nova.nova_objects import Document, Caseworker
 from itk_dev_shared_components.kmd_nova import nova_cases, nova_documents
 
 
@@ -36,6 +36,12 @@ class NovaDocumentsTest(unittest.TestCase):
 
         doc_uuid = nova_documents.upload_document(file, "Filename.txt", self.nova_access)
 
+        caseworker = Caseworker(
+            name='svcitkopeno svcitkopeno',
+            ident='AZX0080',
+            uuid='0bacdddd-5c61-4676-9a61-b01a18cec1d5'
+        )
+
         title = f"Test document {datetime.now()}"
         document = Document(
             uuid=doc_uuid,
@@ -44,7 +50,8 @@ class NovaDocumentsTest(unittest.TestCase):
             document_type="Internt",
             description="Description",
             approved=True,
-            category_uuid='aa015e27-669c-4934-a661-46900351f0aa'
+            category_uuid='aa015e27-669c-4934-a661-46900351f0aa',
+            caseworker=caseworker
         )
 
         nova_documents.attach_document_to_case(case.uuid, document, self.nova_access)
@@ -67,6 +74,7 @@ class NovaDocumentsTest(unittest.TestCase):
         self.assertEqual(document.category_uuid, nova_document.category_uuid)
         self.assertEqual(document.description, nova_document.description)
         self.assertEqual(document.sensitivity, nova_document.sensitivity)
+        self.assertEqual(document.caseworker.ident, nova_document.caseworker.ident)
 
         # Download the document file and check its contents
         file_bytes = nova_documents.download_document_file(document.uuid, self.nova_access)


### PR DESCRIPTION
## [2.1.1] - 2024-04-10

### Fixed

- Documents in Nova can now have a caseworker assigned.