### PR TITLE
`get_notes` now returns an empty tuple instead of raising `KeyError` …

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.3] - 2026-06-29
+
+### Fixed
+
+- `get_notes` now returns an empty tuple instead of raising `KeyError` for Nova cases that have no journal notes.
+
 ## [2.16.2] - 2026-03-13
 
 ### Fixed

--- a/itk_dev_shared_components/kmd_nova/nova_notes.py
+++ b/itk_dev_shared_components/kmd_nova/nova_notes.py
@@ -133,7 +133,8 @@ def get_notes(case_uuid: str, nova_access: NovaAccess, offset: int = 0, limit: i
     response = requests.put(url, params=params, headers=headers, json=payload, timeout=60)
     response.raise_for_status()
 
-    note_dicts = response.json()['cases'][0]['journalNotes']['journalNotes']
+    case = response.json()['cases'][0]
+    note_dicts = case.get('journalNotes', {}).get('journalNotes', [])
 
     notes_list = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "itk_dev_shared_components"
-version = "2.16.2"
+version = "2.16.3"
 authors = [
   { name="ITK Development", email="itk-rpa@mkb.aarhus.dk" },
 ]


### PR DESCRIPTION
…for Nova cases that have no journal notes.